### PR TITLE
Register support for post formats so plugins can make use of it.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -39,4 +39,10 @@ function tj_comment_class( $classname='' ) {
 	return join(' ', apply_filters('comment_class', $c));
 }
 
+// Some plugins, like Tumblr Crosspostr, use this to determine what
+// kind of action to take. We don't need to do anything fancy other
+// than register our support for this to make it all work. So, do it.
+add_theme_support( 'post-formats', array(
+    'link', 'image', 'quote', 'video', 'audio', 'chat'
+) );
 ?>


### PR DESCRIPTION
This commit simply registers support for [WordPress post formats](http://codex.wordpress.org/Post_Formats) in the theme. Nothing particular fancy has to happen other than registering this support so that plugins (like [Tumblr Crosspostr](https://wordpress.org/plugins/tumblr-crosspostr/)) can recognize and make use of the format. I'm already using this on my site without issue.
